### PR TITLE
Fix missing semicolons in generated setters

### DIFF
--- a/src/codegen_source.rs
+++ b/src/codegen_source.rs
@@ -346,7 +346,7 @@ impl<'a, W: Write> CodeSourceGenerator<'a, W> {
                     cg!(self, "{0}& {0}::add_{1}(const {2}{3} {1}) {{", class_name, elem.name(), elem.type_(), reference);
                     self.indent();
                     cg!(self, "this->{0}.emplace_back({0});", elem.name());
-                    cg!(self, "return *this");
+                    cg!(self, "return *this;");
                     self.dedent();
                     cg!(self, "}}");
                     cg!(self);
@@ -355,7 +355,7 @@ impl<'a, W: Write> CodeSourceGenerator<'a, W> {
                     cg!(self, "{0}& {0}::set_{1}(const {2}{3} {1}, size_t index) {{", class_name, elem.name(), elem.type_(), reference);
                     self.indent();
                     cg!(self, "this->{0}[index] = {0};", elem.name());
-                    cg!(self, "return *this");
+                    cg!(self, "return *this;");
                     self.dedent();
                     cg!(self, "}}");
                     cg!(self);


### PR DESCRIPTION
Fixed syntax error in generated setters, would generate body like so:

```cpp
CliShopOpen& CliShopOpen::add_items(const ShopItem& items) {                                                                                                                                             
    this->items.emplace_back(items);                                                                                                                                                                       
    return *this
}                                                                                                                                                                                                   
```

Which is missing a semi-colon after `return *this`